### PR TITLE
Add camera change event. Update camera and world data buffer only on change.

### DIFF
--- a/kirana/app.cpp
+++ b/kirana/app.cpp
@@ -2,7 +2,6 @@
 #include <constants.h>
 #include <file_system.hpp>
 #include <scene_manager.hpp>
-#include <iostream>
 
 using namespace std::placeholders;
 
@@ -11,11 +10,9 @@ namespace constants = kirana::utils::constants;
 void kirana::Application::onWindowResized(const kirana::window::Window *window,
                                           std::array<uint32_t, 2> resolution)
 {
-    std::cout << "Window Resized: " << resolution[0] << "x" << resolution[1]
-              << std::endl;
     if (window == m_viewportWindow.get())
     {
-        m_sceneManager.getCurrentScene().updateCameraResolution(resolution);
+        m_sceneManager.getCurrentScene().getCamera().setResolution(resolution);
     }
 }
 
@@ -108,10 +105,10 @@ void kirana::Application::init()
     else
         m_viewportWindow = m_windowManager.createWindow("Kirana", true, true);
 
-    const scene::Scene &scene = m_sceneManager.loadScene();
+    scene::Scene &scene = m_sceneManager.loadScene();
     if (scene.isInitialized())
     {
-        scene.updateCameraResolution(m_viewportWindow->resolution);
+        scene.getCamera().setResolution(m_viewportWindow->resolution);
         m_logger.log(constants::LOG_CHANNEL_APPLICATION,
                      utils::LogSeverity::debug,
                      "Loaded default scene: " + scene.getRoot()->getName());

--- a/kirana/scene/camera.cpp
+++ b/kirana/scene/camera.cpp
@@ -36,9 +36,9 @@ kirana::scene::Camera &kirana::scene::Camera::operator=(const Camera &camera)
     return *this;
 }
 
-void kirana::scene::Camera::setResolution(std::array<uint32_t, 2> resolution) const
+void kirana::scene::Camera::setResolution(std::array<uint32_t, 2> resolution)
 {
-    m_windowResolution = windowResolution;
+    m_windowResolution = resolution;
     m_aspectRatio = static_cast<float>(m_windowResolution[0]) /
                     static_cast<float>(m_windowResolution[1]);
 }

--- a/kirana/scene/camera.hpp
+++ b/kirana/scene/camera.hpp
@@ -3,6 +3,7 @@
 
 #include <transform.hpp>
 #include <array>
+#include <event.hpp>
 
 namespace kirana::scene
 {
@@ -12,10 +13,12 @@ using math::Transform;
 class Camera
 {
   protected:
-    mutable std::array<uint32_t, 2> m_windowResolution;
+    utils::Event<> m_onCameraChange;
+
+    std::array<uint32_t, 2> m_windowResolution;
     float m_nearPlane = 0.1f;
     float m_farPlane = 1000.0f;
-    mutable float m_aspectRatio;
+    float m_aspectRatio;
 
     Transform m_transform;
     mutable Transform m_projection;
@@ -36,7 +39,17 @@ class Camera
     const float &farPlane = m_farPlane;
     const float &aspectRatio = m_aspectRatio;
 
-    virtual void setResolution(std::array<uint32_t, 2> resolution) const;
+    inline uint32_t addOnCameraChangeEventListener(
+        const std::function<void()> &callback)
+    {
+        return m_onCameraChange.addListener(callback);
+    }
+    inline void removeOnCameraChangeEventListener(uint32_t callbackID)
+    {
+        m_onCameraChange.removeListener(callbackID);
+    }
+
+    virtual void setResolution(std::array<uint32_t, 2> resolution);
 };
 } // namespace kirana::scene
 

--- a/kirana/scene/orthographic_camera.cpp
+++ b/kirana/scene/orthographic_camera.cpp
@@ -36,9 +36,10 @@ kirana::scene::OrthographicCamera &kirana::scene::OrthographicCamera::operator=(
 }
 
 void kirana::scene::OrthographicCamera::setResolution(
-    std::array<uint32_t, 2> resolution) const
+    std::array<uint32_t, 2> resolution)
 {
     Camera::setResolution(resolution);
     m_projection = math::Transform::getOrthographicTransform(
         m_size, m_aspectRatio, m_nearPlane, m_farPlane, m_graphicsAPI, m_flipY);
+    m_onCameraChange();
 }

--- a/kirana/scene/orthographic_camera.hpp
+++ b/kirana/scene/orthographic_camera.hpp
@@ -27,7 +27,7 @@ class OrthographicCamera : public Camera
 
     const float &size = m_size;
 
-    void setResolution(std::array<uint32_t, 2> resolution)const override;
+    void setResolution(std::array<uint32_t, 2> resolution) override;
 };
 } // namespace kirana::scene
 

--- a/kirana/scene/perspective_camera.cpp
+++ b/kirana/scene/perspective_camera.cpp
@@ -35,9 +35,10 @@ kirana::scene::PerspectiveCamera &kirana::scene::PerspectiveCamera::operator=(
 }
 
 void kirana::scene::PerspectiveCamera::setResolution(
-    std::array<uint32_t, 2> resolution) const
+    std::array<uint32_t, 2> resolution)
 {
     Camera::setResolution(resolution);
     m_projection = math::Transform::getPerspectiveTransform(
         m_fov, m_aspectRatio, m_nearPlane, m_farPlane, m_graphicsAPI, m_flipY);
+    m_onCameraChange();
 }

--- a/kirana/scene/perspective_camera.hpp
+++ b/kirana/scene/perspective_camera.hpp
@@ -27,7 +27,7 @@ class PerspectiveCamera : public Camera
 
     const float &fieldOfView = m_fov;
 
-    void setResolution(std::array<uint32_t, 2> resolution)const override;
+    void setResolution(std::array<uint32_t, 2> resolution) override;
 };
 } // namespace kirana::scene
 

--- a/kirana/scene/scene.cpp
+++ b/kirana/scene/scene.cpp
@@ -113,10 +113,3 @@ std::vector<kirana::math::Transform *> kirana::scene::Scene::
     }
     return transforms;
 }
-
-void kirana::scene::Scene::updateCameraResolution(
-    std::array<uint32_t, 2> resolution) const
-{
-    m_camera.setResolution(resolution);
-    m_onCameraChange();
-}

--- a/kirana/scene/scene.hpp
+++ b/kirana/scene/scene.hpp
@@ -24,7 +24,6 @@ class Scene
     friend class SceneManager;
 
   private:
-    utils::Event<> m_onCameraChange;
     utils::Event<> m_onWorldChange;
 
     bool m_isInitialized = false;
@@ -79,24 +78,15 @@ class Scene
     {
         return m_materials;
     }
-    [[nodiscard]] inline const WorldData &getWorldData() const
+    [[nodiscard]] inline WorldData &getWorldData()
     {
         return m_worldData;
     }
-    [[nodiscard]] inline const PerspectiveCamera &getCamera() const
+    [[nodiscard]] inline PerspectiveCamera &getCamera()
     {
         return m_camera;
     }
 
-    inline uint32_t addOnCameraChangeEventListener(
-        const std::function<void()> &callback)
-    {
-        return m_onCameraChange.addListener(callback);
-    }
-    inline void removeOnCameraChangeEventListener(uint32_t callbackID)
-    {
-        m_onCameraChange.removeListener(callbackID);
-    }
     inline uint32_t addOnWorldChangeEventListener(
         const std::function<void()> &callback)
     {
@@ -109,8 +99,6 @@ class Scene
 
     [[nodiscard]] std::vector<math::Transform *> getTransformsForMesh(
         const Mesh *mesh) const;
-
-    void updateCameraResolution(std::array<uint32_t, 2> resolution) const;
 };
 } // namespace kirana::scene
 #endif

--- a/kirana/scene/scene_manager.cpp
+++ b/kirana/scene/scene_manager.cpp
@@ -8,7 +8,7 @@
 
 namespace constants = kirana::utils::constants;
 
-const kirana::scene::Scene &kirana::scene::SceneManager::loadScene(
+kirana::scene::Scene &kirana::scene::SceneManager::loadScene(
     std::string path, const SceneImportSettings &importSettings)
 {
     if (path.empty())

--- a/kirana/scene/scene_manager.hpp
+++ b/kirana/scene/scene_manager.hpp
@@ -24,10 +24,10 @@ class SceneManager
         return instance;
     }
 
-    const Scene &loadScene(std::string path = "",
-                     const SceneImportSettings &importSettings =
-                         DEFAULT_SCENE_IMPORT_SETTINGS);
-    inline const Scene &getCurrentScene() const
+    Scene &loadScene(std::string path = "",
+                           const SceneImportSettings &importSettings =
+                               DEFAULT_SCENE_IMPORT_SETTINGS);
+    inline Scene &getCurrentScene()
     {
         return m_currentScene;
     }

--- a/kirana/viewport/viewport.cpp
+++ b/kirana/viewport/viewport.cpp
@@ -16,7 +16,7 @@ kirana::viewport::Viewport::Viewport()
 }
 
 void kirana::viewport::Viewport::init(const window::Window *window,
-                                      const scene::Scene &scene,
+                                      scene::Scene &scene,
                                       Shading shading)
 {
     m_window = window;

--- a/kirana/viewport/viewport.hpp
+++ b/kirana/viewport/viewport.hpp
@@ -42,7 +42,7 @@ class Viewport
     ~Viewport() = default;
 
     /// Initializes the viewport by binding the window to the renderer (Vulkan).
-    void init(const window::Window *window, const scene::Scene &scene,
+    void init(const window::Window *window, scene::Scene &scene,
               Shading shading = Shading::BASIC);
     /// Calls the update function of the renderer.
     void update();

--- a/kirana/viewport/vulkan/drawer.cpp
+++ b/kirana/viewport/vulkan/drawer.cpp
@@ -149,7 +149,7 @@ void kirana::viewport::vulkan::Drawer::draw()
 
     vk::ClearValue clearDepth;
     clearDepth.setDepthStencil(vk::ClearDepthStencilValue(1.0f));
-
+    
     frame.commandBuffers->reset();
     frame.commandBuffers->begin();
     frame.commandBuffers->beginRenderPass(
@@ -159,8 +159,6 @@ void kirana::viewport::vulkan::Drawer::draw()
 
     if (m_scene)
     {
-        m_scene->updateWorldDataBuffer(getCurrentFrameIndex());
-
         MeshPushConstants meshConstants;
         const MaterialData *lastMatData = nullptr;
         // TODO: Bind Vertex Buffers together and draw them at once.

--- a/kirana/viewport/vulkan/scene_data.hpp
+++ b/kirana/viewport/vulkan/scene_data.hpp
@@ -36,7 +36,9 @@ class SceneData
     const RenderPass *m_renderPass;
     const DescriptorSetLayout *const m_globalDescSetLayout;
 
-    const scene::Scene &m_scene;
+    scene::Scene &m_scene;
+    uint32_t m_cameraChangeListener;
+    uint32_t m_worldChangeListener;
 
     void setVertexDescription();
     const Shader *createShader(const std::string &shaderName);
@@ -46,11 +48,13 @@ class SceneData
 
     MaterialData &findMaterial(const std::string &materialName);
 
+    void onCameraChanged();
+    void onWorldChanged();
   public:
     SceneData(const Device *device, const Allocator *allocator,
               const RenderPass *renderPass,
               const DescriptorSetLayout *globalDescSetLayout,
-              const scene::Scene &scene, uint16_t shadingIndex = 0);
+              scene::Scene &scene, uint16_t shadingIndex = 0);
     ~SceneData();
 
     SceneData(const SceneData &sceneData) = delete;
@@ -66,7 +70,6 @@ class SceneData
 
     [[nodiscard]] const AllocatedBuffer &getWorldDataBuffer() const;
     [[nodiscard]] uint32_t getWorldDataBufferOffset(uint32_t offsetIndex) const;
-    void updateWorldDataBuffer(uint32_t offsetIndex) const;
 };
 } // namespace kirana::viewport::vulkan
 #endif

--- a/kirana/viewport/vulkan/swapchain.cpp
+++ b/kirana/viewport/vulkan/swapchain.cpp
@@ -53,7 +53,7 @@ void kirana::viewport::vulkan::Swapchain::initializeSwapchainData()
     auto presentMode = std::find_if(
         m_supportInfo.presentModes.begin(), m_supportInfo.presentModes.end(),
         [](const vk::PresentModeKHR &p) {
-            return p == vk::PresentModeKHR::eImmediate;
+            return p == vk::PresentModeKHR::eMailbox;
         });
     if (presentMode != m_supportInfo.presentModes.end())
         m_presentMode = *presentMode;

--- a/kirana/viewport/vulkan/vulkan_renderer.cpp
+++ b/kirana/viewport/vulkan/vulkan_renderer.cpp
@@ -19,7 +19,7 @@
 #include <constants.h>
 
 void kirana::viewport::vulkan::VulkanRenderer::init(
-    const window::Window *const window, const scene::Scene &scene,
+    const window::Window *const window, scene::Scene &scene,
     uint16_t shadingIndex)
 {
     m_window = window;

--- a/kirana/viewport/vulkan/vulkan_renderer.hpp
+++ b/kirana/viewport/vulkan/vulkan_renderer.hpp
@@ -63,7 +63,7 @@ class VulkanRenderer
     }
 
     /// Initializes vulkan.
-    void init(const window::Window *window, const scene::Scene &scene,
+    void init(const window::Window *window, scene::Scene &scene,
               uint16_t shadingIndex);
     /// Updates the transforms.
     void update();


### PR DESCRIPTION

- Added camera event. Camera aspect ratio now changes on window resize.
- Made scene object non-const.
- Vulkan viewport buffers for camera and world are now updated only when they are changed.